### PR TITLE
megabyte in equation was incorrectly set as 2 pow 10 changed to 2 pow 20

### DIFF
--- a/scaling.tex
+++ b/scaling.tex
@@ -116,7 +116,7 @@ $28,589\mu{}s$.  Since the workloads are different, we cannot directly
 compare their latency, but we can compute the throughputs as follows:
 
 \begin{align*}
-  Q_{1} =& \frac{2^{10}B}{69\mu{}s} = 15196 \textrm{B}/\mu{}\textrm{s} = 14.2 \textrm{GiB}/\textrm{s} \\
+  Q_{1} =& \frac{2^{20}B}{69\mu{}s} = 15196 \textrm{B}/\mu{}\textrm{s} = 14.2 \textrm{GiB}/\textrm{s} \\
   Q_{2} =& \frac{2^{30}}{28589} = 37558 \textrm{B}/\mu{}\textrm{s} = 35.0 \textrm{GiB}/\textrm{s}
 \end{align*}
 


### PR DESCRIPTION
The equation denoted one megabyte as 2^10 rather than 2^20. Corrected the change. The result of the equation 2^20/69 adds up to the 15196 µs result.